### PR TITLE
feat: add scrollable + header support to Screen, add reusable Header

### DIFF
--- a/src/presentation/components/ui/Header.tsx
+++ b/src/presentation/components/ui/Header.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode } from "react";
+import { Pressable, Text, View } from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+
+type HeaderProps = {
+    title?: string;
+    showBack?: boolean;
+    onBack?: () => void;
+    right?: ReactNode;
+    className?: string;
+};
+
+/**
+ * Default top bar for the `header` slot on `Screen`: back button, centered
+ * title, optional right-side action. Screens that need something bespoke
+ * (e.g. RecipeDetailHeader's image scrim) pass their own node to `header`
+ * instead of using this component.
+ */
+export function Header({ title, showBack = true, onBack, right, className }: HeaderProps) {
+    const router = useRouter();
+
+    return (
+        <View className={`w-full flex-row items-center justify-between px-4 py-3 ${className ?? ""}`}>
+            <View className="min-w-8 items-start">
+                {showBack && (
+                    <Pressable onPress={onBack ?? (() => router.back())} hitSlop={8}>
+                        <MaterialIcons name="arrow-back-ios" size={20} color="#030f09" />
+                    </Pressable>
+                )}
+            </View>
+
+            {title ? (
+                <Text numberOfLines={1} className="flex-1 text-center text-h5 font-nunito-bold text-gray-900">
+                    {title}
+                </Text>
+            ) : (
+                <View className="flex-1" />
+            )}
+
+            <View className="min-w-8 items-end">{right}</View>
+        </View>
+    );
+}

--- a/src/presentation/components/ui/Screen.tsx
+++ b/src/presentation/components/ui/Screen.tsx
@@ -1,12 +1,24 @@
-import React, { PropsWithChildren } from "react";
-import { StyleSheet, View, ViewStyle } from "react-native";
+import React, { PropsWithChildren, ReactNode } from "react";
+import {
+    KeyboardAvoidingView,
+    Platform,
+    ScrollView,
+    StyleSheet,
+    View,
+    ViewStyle,
+    type ScrollViewProps,
+} from "react-native";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 
 import Colors from "../../../constants/Colors";
 
 type ScreenProps = PropsWithChildren<{
     edges?: Edge[];
+    scrollable?: boolean;
+    header?: ReactNode;
     className?: string;
+    contentContainerClassName?: string;
+    keyboardShouldPersistTaps?: ScrollViewProps["keyboardShouldPersistTaps"];
     style?: ViewStyle;
 }>;
 
@@ -14,13 +26,41 @@ type ScreenProps = PropsWithChildren<{
  * SafeAreaView from react-native-safe-area-context does not reliably apply
  * NativeWind `className` — keep this outer element StyleSheet-only and put
  * NativeWind classes on the inner View instead.
+ *
+ * `header` is a plain node rendered above the content, outside the
+ * ScrollView, so it stays pinned while the body scrolls. Pass the shared
+ * `Header` component for the common back/title/action bar, or a fully
+ * custom node (e.g. RecipeDetailHeader) when a screen needs something else.
  */
-export function Screen({ edges = ["top"], className, style, children }: ScreenProps) {
+export function Screen({
+    edges = ["top"],
+    scrollable = false,
+    header,
+    className,
+    contentContainerClassName,
+    keyboardShouldPersistTaps = "handled",
+    style,
+    children,
+}: ScreenProps) {
     return (
         <SafeAreaView edges={edges} style={styles.safeArea}>
-            <View className={className} style={[styles.content, style]}>
-                {children}
-            </View>
+            {header}
+            <KeyboardAvoidingView style={styles.flex} behavior={Platform.OS === "ios" ? "padding" : "height"}>
+                {scrollable ? (
+                    <ScrollView
+                        className={className}
+                        contentContainerClassName={contentContainerClassName}
+                        keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+                        showsVerticalScrollIndicator={false}
+                    >
+                        {children}
+                    </ScrollView>
+                ) : (
+                    <View className={className} style={[styles.content, style]}>
+                        {children}
+                    </View>
+                )}
+            </KeyboardAvoidingView>
         </SafeAreaView>
     );
 }
@@ -29,6 +69,9 @@ const styles = StyleSheet.create({
     safeArea: {
         flex: 1,
         backgroundColor: Colors.light.background,
+    },
+    flex: {
+        flex: 1,
     },
     content: {
         flex: 1,


### PR DESCRIPTION
Screen keeps its existing StyleSheet-based SafeAreaView fix but now accepts a `scrollable` flag (View vs ScrollView content) and a `header` slot rendered above the scroll area, so it stays pinned while content scrolls. Existing call sites are unaffected since both are optional.

Header is the default back/title/action bar for that slot, following the same back-button and title pattern already used ad hoc in AuthHeader/Profile Header/Settings Header. Screens that need something bespoke (e.g. RecipeDetailHeader) still pass their own node.