### PR TITLE
feat: fetch real recipes on the home feed from Firestore

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,34 +1,28 @@
 import React from "react";
-import { ListRenderItemInfo, StyleSheet } from "react-native";
-import { FlatList, View } from "../../src/components/Themed";
+import { StyleSheet } from "react-native";
+import { View } from "../../src/components/Themed";
 import { Screen } from "../../src/presentation/components/ui/Screen";
 import style from "../../src/constants/style";
 
 import Header from "../../src/components/Head";
-import FeedCard from "../../src/components/TabHome/FeedCard";
-import { IHomeItem } from "../../src/components/types";
-import { data } from "../../src/constants/profileData";
+import { FeedScreen } from "../../src/presentation/components/feed/FeedScreen";
+import { useFeed } from "../../src/presentation/hooks/useFeed";
+import { firebaseRecipeRepository } from "../../src/data/repositories/FirebaseRecipeRepository";
+import { firebaseUserRepository } from "../../src/data/repositories/FirebaseUserRepository";
 
 export default function TabHome() {
-
-    function renderItem({ item }: ListRenderItemInfo<IHomeItem>) {
-        return <FeedCard item={item} />;
-    }
-
+    const { data, isLoading, error } = useFeed(firebaseRecipeRepository);
 
     return (
         <Screen style={localStyles.root}>
             <View style={style.horizontalPadding}>
                 <Header />
             </View>
-            <FlatList
-                data={data}
-                contentContainerStyle={localStyles.flatlistContainer}
-                keyExtractor={(item) => item.id}
-                renderItem={renderItem}
-                ListFooterComponent={
-                    <View style={{ marginTop: 15 }} />
-                }
+            <FeedScreen
+                recipes={data?.items ?? []}
+                isLoading={isLoading}
+                error={!!error}
+                userRepository={firebaseUserRepository}
             />
         </Screen>
     )
@@ -37,13 +31,6 @@ export default function TabHome() {
 const localStyles = StyleSheet.create({
     root: {
         paddingHorizontal: 0,
-
+        flex: 1,
     },
-    flatlist: {
-        width: '100%',
-        paddingTop: 15,
-    },
-    flatlistContainer: {
-        ...style.horizontalPadding,
-    }
 })

--- a/src/data/firebase/collections.ts
+++ b/src/data/firebase/collections.ts
@@ -2,3 +2,4 @@ export const RECIPES_COLLECTION = "recipes";
 export const LIKES_COLLECTION = "likes";
 export const SAVES_COLLECTION = "saves";
 export const FOLLOWS_COLLECTION = "follows";
+export const USERS_COLLECTION = "users";

--- a/src/data/mappers/__tests__/userMapper.test.ts
+++ b/src/data/mappers/__tests__/userMapper.test.ts
@@ -1,0 +1,51 @@
+import { UserDraft } from "../../../domain/repositories/IUserRepository";
+import { toUserDocData, toUserEntity } from "../userMapper";
+
+describe("userMapper", () => {
+    describe("toUserEntity", () => {
+        it("maps a Firestore doc to a User", () => {
+            const snap = {
+                id: "u1",
+                data: () => ({
+                    name: "Tadeu Melembe",
+                    email: "tadeu@example.com",
+                    avatarUrl: null,
+                }),
+            } as any;
+
+            const user = toUserEntity(snap);
+
+            expect(user).toEqual({
+                id: "u1",
+                name: "Tadeu Melembe",
+                email: "tadeu@example.com",
+                avatarUrl: null,
+            });
+        });
+
+        it("defaults missing fields to null", () => {
+            const snap = { id: "u1", data: () => ({}) } as any;
+
+            const user = toUserEntity(snap);
+
+            expect(user).toEqual({ id: "u1", name: null, email: null, avatarUrl: null });
+        });
+    });
+
+    describe("toUserDocData", () => {
+        it("maps a UserDraft to Firestore doc data", () => {
+            const draft: UserDraft = {
+                id: "u1",
+                name: "Tadeu Melembe",
+                email: "tadeu@example.com",
+                avatarUrl: null,
+            };
+
+            expect(toUserDocData(draft)).toEqual({
+                name: "Tadeu Melembe",
+                email: "tadeu@example.com",
+                avatarUrl: null,
+            });
+        });
+    });
+});

--- a/src/data/mappers/userMapper.ts
+++ b/src/data/mappers/userMapper.ts
@@ -1,0 +1,29 @@
+import { DocumentData, DocumentSnapshot, QueryDocumentSnapshot } from "firebase/firestore";
+
+import { User } from "../../domain/entities/User";
+import { UserDraft } from "../../domain/repositories/IUserRepository";
+
+export interface UserDocData {
+    name: string | null;
+    email: string | null;
+    avatarUrl: string | null;
+}
+
+export function toUserEntity(snap: DocumentSnapshot<DocumentData> | QueryDocumentSnapshot<DocumentData>): User {
+    const data = snap.data() as UserDocData;
+
+    return {
+        id: snap.id,
+        name: data.name ?? null,
+        email: data.email ?? null,
+        avatarUrl: data.avatarUrl ?? null,
+    };
+}
+
+export function toUserDocData(draft: UserDraft): UserDocData {
+    return {
+        name: draft.name,
+        email: draft.email,
+        avatarUrl: draft.avatarUrl,
+    };
+}

--- a/src/data/repositories/FirebaseUserRepository.ts
+++ b/src/data/repositories/FirebaseUserRepository.ts
@@ -1,0 +1,25 @@
+import { Firestore, doc, getDoc, setDoc } from "firebase/firestore";
+
+import { User, UserId } from "../../domain/entities/User";
+import { IUserRepository, UserDraft } from "../../domain/repositories/IUserRepository";
+import { db } from "../firebase/client";
+import { USERS_COLLECTION } from "../firebase/collections";
+import { toUserDocData, toUserEntity } from "../mappers/userMapper";
+
+export class FirebaseUserRepository implements IUserRepository {
+    constructor(private readonly firestore: Firestore = db) {}
+
+    async getById(id: UserId): Promise<User | null> {
+        const snap = await getDoc(doc(this.firestore, USERS_COLLECTION, id));
+        if (!snap.exists()) return null;
+        return toUserEntity(snap);
+    }
+
+    async create(draft: UserDraft): Promise<User> {
+        const userRef = doc(this.firestore, USERS_COLLECTION, draft.id);
+        await setDoc(userRef, toUserDocData(draft));
+        return { ...draft };
+    }
+}
+
+export const firebaseUserRepository = new FirebaseUserRepository();

--- a/src/data/repositories/InMemoryUserRepository.ts
+++ b/src/data/repositories/InMemoryUserRepository.ts
@@ -1,0 +1,20 @@
+import { User, UserId } from "../../domain/entities/User";
+import { IUserRepository, UserDraft } from "../../domain/repositories/IUserRepository";
+
+export class InMemoryUserRepository implements IUserRepository {
+    private users: User[];
+
+    constructor(seed: User[] = []) {
+        this.users = [...seed];
+    }
+
+    async getById(id: UserId): Promise<User | null> {
+        return this.users.find((u) => u.id === id) ?? null;
+    }
+
+    async create(draft: UserDraft): Promise<User> {
+        const user: User = { ...draft };
+        this.users = [...this.users.filter((u) => u.id !== user.id), user];
+        return user;
+    }
+}

--- a/src/data/repositories/__tests__/InMemoryUserRepository.test.ts
+++ b/src/data/repositories/__tests__/InMemoryUserRepository.test.ts
@@ -1,0 +1,35 @@
+import { InMemoryUserRepository } from "../InMemoryUserRepository";
+
+const draft = {
+    id: "u1",
+    name: "Tadeu Melembe",
+    email: "tadeu@example.com",
+    avatarUrl: null,
+};
+
+describe("InMemoryUserRepository", () => {
+    it("creates and reads a user back", async () => {
+        const repository = new InMemoryUserRepository();
+
+        const created = await repository.create(draft);
+        const found = await repository.getById(created.id);
+
+        expect(found).toEqual(created);
+    });
+
+    it("returns null for a missing user", async () => {
+        const repository = new InMemoryUserRepository();
+
+        expect(await repository.getById("missing")).toBeNull();
+    });
+
+    it("overwrites an existing user with the same id", async () => {
+        const repository = new InMemoryUserRepository();
+        await repository.create(draft);
+
+        await repository.create({ ...draft, name: "Tadeu M." });
+        const found = await repository.getById(draft.id);
+
+        expect(found?.name).toBe("Tadeu M.");
+    });
+});

--- a/src/domain/repositories/IUserRepository.ts
+++ b/src/domain/repositories/IUserRepository.ts
@@ -1,5 +1,13 @@
 import { User, UserId } from "../entities/User";
 
+export interface UserDraft {
+    id: UserId;
+    name: string | null;
+    email: string | null;
+    avatarUrl: string | null;
+}
+
 export interface IUserRepository {
     getById(id: UserId): Promise<User | null>;
+    create(draft: UserDraft): Promise<User>;
 }

--- a/src/domain/usecases/__tests__/getFeed.test.ts
+++ b/src/domain/usecases/__tests__/getFeed.test.ts
@@ -1,0 +1,32 @@
+import { InMemoryRecipeRepository } from "../../../data/repositories/InMemoryRecipeRepository";
+import { getFeed } from "../getFeed";
+
+const draft = {
+    authorId: "u1",
+    title: "Vanilla Pudding",
+    description: null,
+    coverImageUrl: null,
+    ingredients: [],
+    directions: [],
+};
+
+describe("getFeed", () => {
+    it("returns the recipes page from the repository", async () => {
+        const repository = new InMemoryRecipeRepository();
+        const first = await repository.create(draft);
+        const second = await repository.create({ ...draft, title: "Chocolate Pudding" });
+
+        const page = await getFeed(repository)();
+
+        expect(page.items).toEqual([first, second]);
+        expect(page.nextCursor).toBeNull();
+    });
+
+    it("returns an empty page when there are no recipes", async () => {
+        const repository = new InMemoryRecipeRepository();
+
+        const page = await getFeed(repository)();
+
+        expect(page.items).toEqual([]);
+    });
+});

--- a/src/domain/usecases/__tests__/getUserById.test.ts
+++ b/src/domain/usecases/__tests__/getUserById.test.ts
@@ -1,0 +1,26 @@
+import { InMemoryUserRepository } from "../../../data/repositories/InMemoryUserRepository";
+import { getUserById } from "../getUserById";
+
+describe("getUserById", () => {
+    it("returns the user when it exists", async () => {
+        const repository = new InMemoryUserRepository();
+        const created = await repository.create({
+            id: "u1",
+            name: "Tadeu Melembe",
+            email: "tadeu@example.com",
+            avatarUrl: null,
+        });
+
+        const user = await getUserById(repository)(created.id);
+
+        expect(user).toEqual(created);
+    });
+
+    it("returns null when the user does not exist", async () => {
+        const repository = new InMemoryUserRepository();
+
+        const user = await getUserById(repository)("missing");
+
+        expect(user).toBeNull();
+    });
+});

--- a/src/domain/usecases/getFeed.ts
+++ b/src/domain/usecases/getFeed.ts
@@ -1,0 +1,7 @@
+import { Page } from "../entities/Page";
+import { Recipe } from "../entities/Recipe";
+import { IRecipeRepository } from "../repositories/IRecipeRepository";
+
+export function getFeed(recipes: IRecipeRepository) {
+    return (cursor?: string): Promise<Page<Recipe>> => recipes.getFeed(cursor);
+}

--- a/src/domain/usecases/getUserById.ts
+++ b/src/domain/usecases/getUserById.ts
@@ -1,0 +1,6 @@
+import { User, UserId } from "../entities/User";
+import { IUserRepository } from "../repositories/IUserRepository";
+
+export function getUserById(users: IUserRepository) {
+    return (id: UserId): Promise<User | null> => users.getById(id);
+}

--- a/src/presentation/components/feed/FeedCard.tsx
+++ b/src/presentation/components/feed/FeedCard.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Image, Pressable, Text, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+
+import { Recipe } from "../../../domain/entities/Recipe";
+import { IUserRepository } from "../../../domain/repositories/IUserRepository";
+import { formatRelativeTime, getInitials } from "../../../utils/helpers";
+import { useUser } from "../../hooks/useUser";
+
+export function FeedCard({ recipe, userRepository }: { recipe: Recipe; userRepository: IUserRepository }) {
+    const router = useRouter();
+    const { data: author } = useUser(recipe.authorId, userRepository);
+    const authorName = author?.name ?? null;
+
+    return (
+        <Pressable
+            onPress={() => router.push(`/recipe/${recipe.id}`)}
+            className="w-full mb-5 rounded-[10px] bg-white shadow-card overflow-hidden"
+        >
+            <View className="flex-row items-center px-4 py-3">
+                <View className="w-9 h-9 rounded-full bg-primary-soft items-center justify-center">
+                    <Text className="font-nunito-bold text-caption text-primary">{getInitials(authorName)}</Text>
+                </View>
+                <View className="ml-2.5">
+                    <Text className="font-nunito-medium text-body text-gray-900">{authorName ?? "Unknown cook"}</Text>
+                    <Text className="font-nunito-regular text-caption text-gray-400">
+                        {formatRelativeTime(recipe.createdAt)}
+                    </Text>
+                </View>
+            </View>
+
+            {recipe.coverImageUrl && (
+                <Image source={{ uri: recipe.coverImageUrl }} resizeMode="cover" className="w-full h-[200px]" />
+            )}
+
+            <View className="p-4">
+                <Text className="text-h5 font-nunito-medium text-gray-900">{recipe.title}</Text>
+
+                {recipe.description && (
+                    <Text
+                        numberOfLines={2}
+                        className="text-body font-nunito-regular text-gray-500 mt-2"
+                    >
+                        {recipe.description}
+                    </Text>
+                )}
+
+                <View className="flex-row items-center mt-3">
+                    <Ionicons
+                        name={recipe.isLikedByViewer ? "heart" : "heart-outline"}
+                        size={18}
+                        color={recipe.isLikedByViewer ? "#f84971" : "#767676"}
+                    />
+                    <Text className="ml-1 text-caption font-nunito-regular text-gray-500">{recipe.likeCount}</Text>
+                </View>
+            </View>
+        </Pressable>
+    );
+}

--- a/src/presentation/components/feed/FeedScreen.tsx
+++ b/src/presentation/components/feed/FeedScreen.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { ActivityIndicator, FlatList, Text, View } from "react-native";
+
+import { Recipe } from "../../../domain/entities/Recipe";
+import { IUserRepository } from "../../../domain/repositories/IUserRepository";
+import { FeedCard } from "./FeedCard";
+
+export function FeedScreen({
+    recipes,
+    isLoading,
+    error,
+    userRepository,
+}: {
+    recipes: Recipe[];
+    isLoading: boolean;
+    error: boolean;
+    userRepository: IUserRepository;
+}) {
+    if (isLoading) {
+        return (
+            <View className="flex-1 items-center justify-center">
+                <ActivityIndicator />
+            </View>
+        );
+    }
+
+    if (error) {
+        return (
+            <View className="flex-1 items-center justify-center px-4">
+                <Text className="text-body font-nunito-regular text-gray-500">Couldn't load the feed.</Text>
+            </View>
+        );
+    }
+
+    return (
+        <FlatList
+            data={recipes}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => <FeedCard recipe={item} userRepository={userRepository} />}
+            contentContainerClassName="px-4 pt-4 pb-6"
+            showsVerticalScrollIndicator={false}
+            ListEmptyComponent={
+                <Text className="text-body font-nunito-regular text-gray-400 text-center mt-10">
+                    No recipes yet. Be the first to publish one!
+                </Text>
+            }
+        />
+    );
+}

--- a/src/presentation/components/feed/__tests__/FeedCard.test.tsx
+++ b/src/presentation/components/feed/__tests__/FeedCard.test.tsx
@@ -1,0 +1,54 @@
+import React, { PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+
+import { InMemoryUserRepository } from "../../../../data/repositories/InMemoryUserRepository";
+import { Recipe } from "../../../../domain/entities/Recipe";
+import { FeedCard } from "../FeedCard";
+
+jest.mock("expo-router", () => ({
+    useRouter: () => ({ push: jest.fn() }),
+}));
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+}
+
+const recipe: Recipe = {
+    id: "r1",
+    authorId: "u1",
+    title: "Vanilla Pudding",
+    description: "Creamy and simple.",
+    coverImageUrl: null,
+    ingredients: [],
+    directions: [],
+    createdAt: new Date().toISOString(),
+    likeCount: 3,
+    isLikedByViewer: false,
+    isSavedByViewer: false,
+};
+
+describe("FeedCard", () => {
+    it("renders the recipe title and the fetched author name", async () => {
+        const userRepository = new InMemoryUserRepository();
+        await userRepository.create({ id: "u1", name: "Tadeu Melembe", email: null, avatarUrl: null });
+
+        render(<FeedCard recipe={recipe} userRepository={userRepository} />, { wrapper: createWrapper() });
+
+        expect(screen.getByText("Vanilla Pudding")).toBeOnTheScreen();
+        await waitFor(() => expect(screen.getByText("Tadeu Melembe")).toBeOnTheScreen());
+    });
+
+    it("falls back to 'Unknown cook' when there is no author profile", async () => {
+        const userRepository = new InMemoryUserRepository();
+
+        render(<FeedCard recipe={recipe} userRepository={userRepository} />, { wrapper: createWrapper() });
+
+        await waitFor(() => expect(screen.getByText("Unknown cook")).toBeOnTheScreen());
+    });
+});

--- a/src/presentation/hooks/__tests__/useFeed.test.tsx
+++ b/src/presentation/hooks/__tests__/useFeed.test.tsx
@@ -1,0 +1,37 @@
+import React, { PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react-native";
+
+import { InMemoryRecipeRepository } from "../../../data/repositories/InMemoryRecipeRepository";
+import { useFeed } from "../useFeed";
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+}
+
+describe("useFeed", () => {
+    it("resolves the feed page from the repository", async () => {
+        const repository = new InMemoryRecipeRepository();
+        const created = await repository.create({
+            authorId: "u1",
+            title: "Vanilla Pudding",
+            description: null,
+            coverImageUrl: null,
+            ingredients: [],
+            directions: [],
+        });
+
+        const { result } = renderHook(() => useFeed(repository), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(result.current.data?.items).toEqual([created]);
+    });
+});

--- a/src/presentation/hooks/__tests__/useUser.test.tsx
+++ b/src/presentation/hooks/__tests__/useUser.test.tsx
@@ -1,0 +1,35 @@
+import React, { PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react-native";
+
+import { InMemoryUserRepository } from "../../../data/repositories/InMemoryUserRepository";
+import { useUser } from "../useUser";
+
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+}
+
+describe("useUser", () => {
+    it("resolves the user from the repository", async () => {
+        const repository = new InMemoryUserRepository();
+        const created = await repository.create({
+            id: "u1",
+            name: "Tadeu Melembe",
+            email: "tadeu@example.com",
+            avatarUrl: null,
+        });
+
+        const { result } = renderHook(() => useUser(created.id, repository), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(result.current.data).toEqual(created);
+    });
+});

--- a/src/presentation/hooks/queryKeys.ts
+++ b/src/presentation/hooks/queryKeys.ts
@@ -5,6 +5,7 @@ export const queryKeys = {
         detail: (id: string) => [...queryKeys.recipes.all, "detail", id] as const,
     },
     users: {
+        detail: (id: string) => ["users", id, "detail"] as const,
         saved: (id: string) => ["users", id, "saved"] as const,
     },
 };

--- a/src/presentation/hooks/useFeed.ts
+++ b/src/presentation/hooks/useFeed.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { IRecipeRepository } from "../../domain/repositories/IRecipeRepository";
+import { getFeed } from "../../domain/usecases/getFeed";
+import { queryKeys } from "./queryKeys";
+
+export function useFeed(recipeRepository: IRecipeRepository) {
+    return useQuery({
+        queryKey: queryKeys.recipes.feed(),
+        queryFn: () => getFeed(recipeRepository)(),
+    });
+}

--- a/src/presentation/hooks/useUser.ts
+++ b/src/presentation/hooks/useUser.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { IUserRepository } from "../../domain/repositories/IUserRepository";
+import { getUserById } from "../../domain/usecases/getUserById";
+import { queryKeys } from "./queryKeys";
+
+export function useUser(id: string, userRepository: IUserRepository) {
+    return useQuery({
+        queryKey: queryKeys.users.detail(id),
+        queryFn: () => getUserById(userRepository)(id),
+        enabled: !!id,
+    });
+}

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -1,5 +1,6 @@
 import { createUserWithEmailAndPassword, signInWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { auth } from "../../../firebaseConfig";
+import { firebaseUserRepository } from "../../data/repositories/FirebaseUserRepository";
 
 interface IUser {
     email: string;
@@ -12,6 +13,16 @@ async function create(user: IUser) {
 
     await updateProfile(authUser, {
         displayName: user.name,
+    })
+
+    // The feed and other cooks' views read author info from this Firestore
+    // doc, not from Firebase Auth (the client SDK can't look up another
+    // user's Auth profile by uid).
+    await firebaseUserRepository.create({
+        id: authUser.uid,
+        name: user.name ?? null,
+        email: user.email,
+        avatarUrl: null,
     })
 
     // onAuthStateChanged already fired when the account was created, back when

--- a/src/utils/__tests__/helpers.test.ts
+++ b/src/utils/__tests__/helpers.test.ts
@@ -1,4 +1,4 @@
-import { getInitials } from '../helpers'
+import { formatRelativeTime, getInitials } from '../helpers'
 
 describe('getInitials', () => {
     it('takes the first and last word', () => {
@@ -18,5 +18,34 @@ describe('getInitials', () => {
         expect(getInitials(undefined)).toBe('')
         expect(getInitials(null)).toBe('')
         expect(getInitials('   ')).toBe('')
+    })
+})
+
+describe('formatRelativeTime', () => {
+    const now = new Date('2026-01-01T12:00:00.000Z')
+
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(now)
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it('buckets seconds as "just now"', () => {
+        expect(formatRelativeTime(new Date(now.getTime() - 30 * 1000).toISOString())).toBe('just now')
+    })
+
+    it('buckets minutes', () => {
+        expect(formatRelativeTime(new Date(now.getTime() - 5 * 60 * 1000).toISOString())).toBe('5min ago')
+    })
+
+    it('buckets hours', () => {
+        expect(formatRelativeTime(new Date(now.getTime() - 3 * 60 * 60 * 1000).toISOString())).toBe('3h ago')
+    })
+
+    it('buckets days, pluralizing when more than one', () => {
+        expect(formatRelativeTime(new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString())).toBe('1day ago')
+        expect(formatRelativeTime(new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString())).toBe('2days ago')
     })
 })

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -1,3 +1,18 @@
+/** ISO date -> "2min ago" / "3h ago" / "5days ago", buckets no finer than a minute. */
+export const formatRelativeTime = (isoDate: string) => {
+    const diffMs = Date.now() - new Date(isoDate).getTime()
+    const minutes = Math.floor(diffMs / 60000)
+
+    if (minutes < 1) return 'just now'
+    if (minutes < 60) return `${minutes}min ago`
+
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h ago`
+
+    const days = Math.floor(hours / 24)
+    return `${days}day${days > 1 ? 's' : ''} ago`
+}
+
 /** "Tadeu Melembe" -> "TM", "Itan" -> "I", missing name -> "". */
 export const getInitials = (name?: string | null) => {
     const words = name?.trim().split(/\s+/).filter(Boolean) ?? []


### PR DESCRIPTION
Wires the home tab to IRecipeRepository.getFeed via a new getFeed use case and useFeed hook, replacing the hardcoded profileData mock, on the same use-case/hook pattern the recipe detail slice already uses.

Recipe only stores authorId with no denormalized author info, and there was no Firestore users collection or IUserRepository implementation to look one up. Adds a users/{uid} doc written at sign-up, FirebaseUserRepository/InMemoryUserRepository, and a useUser hook so the new NativeWind FeedCard can show the author's name.